### PR TITLE
Add Docker support for easier environment variable setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Locally imported server environment variables
+env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Base docker image
+FROM python:3
+
+# Send python output straight to terminal
+ENV PYTHONUNBUFFERED=1
+
+# Install Microsoft ODBC SQL driver
+# https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15#debian17
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+RUN apt-get update
+RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17
+
+# Install ODBC headers, required by Django
+RUN apt-get install -y unixodbc-dev
+RUN apt-get clean -y
+
+WORKDIR /code
+
+# Install Python requirements
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+# Copy remaining source code
+COPY ./cc_midterm ./
+
+# Run server, listening for any IP at port 8000
+CMD python manage.py runserver 0:8000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # Cloud-Computing-Midterm
+
+## Overview
+
+This repo contains our Cloud Computing midterm for Spring 2021, tasking us to
+learn Microsoft Azure while analyzing how to make a customer's life easier with
+preset data.
+
+## Development
+
+### Installation
+
+1. Install `docker`
+1. Clone repo
+1. Retrieve an `env` file from one of the contributors
+1. Place `env` file within the top directory of the repo
+
+### Build
+
+`sh ./build.sh`
+
+This will build a docker image locally
+
+### Run
+
+`sh ./run.sh`
+
+This will run the built docker image. If run successfully, it will create a
+server accessible at `http://127.0.0.1:8000`.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+# Build the docker container locally, using Dockerfile as configuration
+docker build -t cc_midterm .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# pip-require file for keeping centralized requirements
+Django==3.0.10
+pyodbc>=4.0
+django-mssql-backend==2.8.1

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+# Shell script to run the docker image locally at port 8000
+# Requires "env" file is downloaded and put in this directory
+docker run -itp 8000:8000 --env-file env cc_midterm


### PR DESCRIPTION
## Overview

Instead of running the Django instance locally with environment variables set up, this sets up the repo to instead use `docker`, allowing us to hop between machines and not worry about getting development setups perfectly. This should also allow for fairly easy deployment to the Azure instance in the future.

## Setup

To run this now, you will need an `env` file supplied by someone who already has it, containing the environment variables necessary for the server to connect to the database. This should be placed within the top directory of this repository, where it is retrieved when building docker

Obviously, you must also have `docker` installed locally, but no further dependencies should be required

## Usage

See the new instructions in the `README.md`. If there are any questions, we should update the documentation there to answer them directly!