### PR TITLE
Initialize front-end with basic proof-of-concept data

### DIFF
--- a/cc_midterm/cc_midterm/settings.py
+++ b/cc_midterm/cc_midterm/settings.py
@@ -16,6 +16,8 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Path to this directory
+SETTINGS_PATH = os.path.normpath(os.path.dirname(__file__))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
@@ -38,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'cc_midterm',
 ]
 
 MIDDLEWARE = [
@@ -66,6 +69,10 @@ TEMPLATES = [
             ],
         },
     },
+]
+
+TEMPLATE_DIRS = [
+    os.path.join(SETTINGS_PATH, 'templates')
 ]
 
 WSGI_APPLICATION = 'cc_midterm.wsgi.application'

--- a/cc_midterm/cc_midterm/templates/index.html
+++ b/cc_midterm/cc_midterm/templates/index.html
@@ -1,0 +1,3 @@
+<html>
+  <h1>Test</h1>
+</html>

--- a/cc_midterm/cc_midterm/templates/pie_chart.html
+++ b/cc_midterm/cc_midterm/templates/pie_chart.html
@@ -1,0 +1,33 @@
+{% block content %}
+  <div id="container" style="width: 100%;">
+    <canvas id="pie-chart"></canvas>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
+  <script>
+
+    var config = {
+      type: 'pie',
+      data: {
+        datasets: [{
+          data: {{ data|safe }},
+          backgroundColor: [
+            '#696969', '#808080', '#A9A9A9', '#C0C0C0', '#D3D3D3'
+          ],
+          label: 'Population'
+        }],
+        labels: {{ labels|safe }}
+      },
+      options: {
+        responsive: true
+      }
+    };
+
+    window.onload = function() {
+      var ctx = document.getElementById('pie-chart').getContext('2d');
+      window.myPie = new Chart(ctx, config);
+    };
+
+  </script>
+
+{% endblock %}

--- a/cc_midterm/cc_midterm/urls.py
+++ b/cc_midterm/cc_midterm/urls.py
@@ -19,6 +19,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.home),
+    path('', views.home, name='home'),
+    path('pie-chart/', views.pie_chart, name='pie-chart'),
     path('admin/', admin.site.urls),
 ]

--- a/cc_midterm/cc_midterm/urls.py
+++ b/cc_midterm/cc_midterm/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from . import views
+
 urlpatterns = [
+    path('', views.home),
     path('admin/', admin.site.urls),
 ]

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -1,6 +1,44 @@
 from django.http import HttpResponse
 from django.template import loader
+from django.shortcuts import render
 
 def home(request):
     template = loader.get_template('index.html')
     return HttpResponse(template.render(None, request))
+
+def pie_chart(request):
+    test_data = [
+        {
+            'id': 1,
+            'name': 'Tokyo',
+            'country_id': 28,
+            'population': 36923000,
+        }, {
+            'id': 2,
+            'name': 'Shanghai',
+            'country_id': 13,
+            'population': 34000000,
+        }, {
+            'id': 3,
+            'name': 'Jakarta',
+            'country_id': 19,
+            'population': 30000000,
+        }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
+            'id': 5,
+            'name': 'Guangzhou',
+            'country_id': 13,
+            'population': 25000000,
+        }]
+
+    labels = [x['name'] for x in test_data]
+    data = [x['population'] for x in test_data]
+
+    return render(request, 'pie_chart.html', {
+        'labels': labels,
+        'data': data,
+    })

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -1,0 +1,6 @@
+from django.http import HttpResponse
+from django.template import loader
+
+def home(request):
+    template = loader.get_template('index.html')
+    return HttpResponse(template.render(None, request))


### PR DESCRIPTION
This PR initializes some necessary logic to start front-end development, as well as confirms Chart.js will be of use to us (which it seems it will!)

As of right now, we have:

- `127.0.0.1:8000/` = a very basic test screen
- `127.0.0.1:8000/pie-chart` = pie chart filled with test data

I have been using [this article](https://simpleisbetterthancomplex.com/tutorial/2020/01/19/how-to-use-chart-js-with-django.html) for reference regarding Chart.js, but I will personally need to look more into Django's template system to see how to make charts like `pie-chart` more functional for general use, which could allow us to simply "plug-and-play" mess with the dashboard as we see fit.