### PR TITLE
Add line chart and make all charts more general

### DIFF
--- a/cc_midterm/cc_midterm/templates/line_chart_labeled.html
+++ b/cc_midterm/cc_midterm/templates/line_chart_labeled.html
@@ -1,0 +1,65 @@
+{% comment %}
+
+Basic line chart that uses labels along the bottom for time-based items
+
+Example usage:
+  render(request, 'line_chart_labeled.html', {
+      'title': 'City Population 2020',
+
+      'xLabel': 'Month',
+      'labels': ['April', 'May', 'June'],
+
+      'yLabel': 'Population',
+      'data': [100, 200, 300000],
+
+      'backgroundColor': '#404040',
+      'borderColor': '#606060',
+  })
+
+{% endcomment %}
+
+{% block content %}
+  <div id="container" style="width: 60%;">
+    <canvas id="line-chart-labeled"></canvas>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
+  <script>
+    var config = {
+      type: 'line',
+      data: {
+        datasets: [{
+          data: {{ data|safe }},
+          backgroundColor: '{{ backgroundColor|safe }}',
+          borderColor: '{{ borderColor|safe }}',
+          label: '{{ title|safe }}',
+        }],
+        labels: {{ labels|safe }}
+      },
+      options: {
+        responsive: true,
+        scales: {
+          xAxes: [{
+            scaleLabel: {
+              display: true,
+              labelString: '{{ xLabel|safe }}',
+            },
+          }],
+          yAxes: [{
+            scaleLabel: {
+              display: true,
+              labelString: '{{ yLabel|safe }}',
+            },
+          }],
+        },
+      }
+    };
+
+    window.onload = function() {
+      var ctx = document.getElementById('line-chart-labeled').getContext('2d');
+      window.myLine = new Chart(ctx, config);
+    };
+
+  </script>
+
+{% endblock %}

--- a/cc_midterm/cc_midterm/templates/pie_chart.html
+++ b/cc_midterm/cc_midterm/templates/pie_chart.html
@@ -12,9 +12,8 @@
         datasets: [{
           data: {{ data|safe }},
           backgroundColor: [
-            '#696969', '#808080', '#A9A9A9', '#C0C0C0', '#D3D3D3'
           ],
-          label: 'Population'
+          label: '{{ title|safe }}',
         }],
         labels: {{ labels|safe }}
       },
@@ -26,6 +25,38 @@
     window.onload = function() {
       var ctx = document.getElementById('pie-chart').getContext('2d');
       window.myPie = new Chart(ctx, config);
+
+      // Colors to use, retrieved from the pastel (top row) of:
+      // https://flatuicolors.com/palette/ru
+      const flatUiColors = [
+        '#f3a683', '#f7d794', '#778beb', '#e77f67', '#cf6a87',
+        '#786fa6', '#f8a5c2', '#63cdda', '#ea8685', '#596275'
+      ]
+
+      // Generate enough background colors for the given data
+      const dataset = myPie.data.datasets[0]
+      const dataCount = dataset.data.length
+      const backgroundCount = flatUiColors.length
+
+      const backgroundRepeats = Math.ceil(dataCount / flatUiColors.length)
+      const extraItems = dataCount % backgroundRepeats
+      const lastSliceIndex = backgroundRepeats * backgroundCount - (backgroundCount - extraItems)
+
+      const backgroundColors = [...Array(backgroundRepeats)]
+        // Copy over the colors
+        .map((x) => flatUiColors)
+        .flat()
+        // Remove any extra colors
+        .slice(0, lastSliceIndex)
+
+      // Disable the case where first & last areas could be the same color
+      if (extraItems === 1) {
+        backgroundColors[backgroundColors.length - 1] = flatUiColors[2]
+      }
+
+      // Update graph and reload
+      dataset.backgroundColor = backgroundColors
+      myPie.update()
     };
 
   </script>

--- a/cc_midterm/cc_midterm/templates/pie_chart.html
+++ b/cc_midterm/cc_midterm/templates/pie_chart.html
@@ -1,3 +1,18 @@
+{% comment %}
+
+Basic pie chart
+Will repeat given background colors as necessary to fit data
+
+Example usage:
+  return render(request, 'pie_chart.html', {
+      'title': 'Population',
+      'labels': ['Shanghai', 'Cincinnati', 'Guam'],
+      'data': [300, 3000, 20],
+      'backgroundColors': ['#606060', '#202020'],
+  })
+
+{% endcomment %}
+
 {% block content %}
   <div id="container" style="width: 100%;">
     <canvas id="pie-chart"></canvas>

--- a/cc_midterm/cc_midterm/templates/pie_chart.html
+++ b/cc_midterm/cc_midterm/templates/pie_chart.html
@@ -11,8 +11,7 @@
       data: {
         datasets: [{
           data: {{ data|safe }},
-          backgroundColor: [
-          ],
+          backgroundColor: [],
           label: '{{ title|safe }}',
         }],
         labels: {{ labels|safe }}
@@ -26,36 +25,31 @@
       var ctx = document.getElementById('pie-chart').getContext('2d');
       window.myPie = new Chart(ctx, config);
 
-      // Colors to use, retrieved from the pastel (top row) of:
-      // https://flatuicolors.com/palette/ru
-      const flatUiColors = [
-        '#f3a683', '#f7d794', '#778beb', '#e77f67', '#cf6a87',
-        '#786fa6', '#f8a5c2', '#63cdda', '#ea8685', '#596275'
-      ]
+      const backgroundColors = {{ backgroundColors|safe }}
 
       // Generate enough background colors for the given data
       const dataset = myPie.data.datasets[0]
       const dataCount = dataset.data.length
-      const backgroundCount = flatUiColors.length
+      const backgroundCount = backgroundColors.length
 
-      const backgroundRepeats = Math.ceil(dataCount / flatUiColors.length)
+      const backgroundRepeats = Math.ceil(dataCount / backgroundColors.length)
       const extraItems = dataCount % backgroundRepeats
       const lastSliceIndex = backgroundRepeats * backgroundCount - (backgroundCount - extraItems)
 
-      const backgroundColors = [...Array(backgroundRepeats)]
+      const backgroundsRepeated = [...Array(backgroundRepeats)]
         // Copy over the colors
-        .map((x) => flatUiColors)
+        .map((x) => backgroundColors)
         .flat()
         // Remove any extra colors
         .slice(0, lastSliceIndex)
 
       // Disable the case where first & last areas could be the same color
       if (extraItems === 1) {
-        backgroundColors[backgroundColors.length - 1] = flatUiColors[2]
+        backgroundsRepeated[backgroundsRepeated.length - 1] = backgroundColors[2]
       }
 
       // Update graph and reload
-      dataset.backgroundColor = backgroundColors
+      dataset.backgroundColor = backgroundsRepeated
       myPie.update()
     };
 

--- a/cc_midterm/cc_midterm/urls.py
+++ b/cc_midterm/cc_midterm/urls.py
@@ -21,9 +21,11 @@ from . import views
 
 urlpatterns = [
     path('', views.home, name='home'),
-    path('pie-chart/', views.pie_chart, name='pie-chart'),
     path('admin/', admin.site.urls),
     path('login/', LoginView.as_view(template_name='login.html'), name='login'),
     path('logout/', LogoutView.as_view(template_name='logout.html'), name='logout'),
-    path('signup/', views.signup, name='signup')
+    path('signup/', views.signup, name='signup'),
+    # Temp for testing
+    path('pie-chart/', views.pie_chart, name='pie-chart'),
+    path('line-chart-labeled/', views.line_chart_labeled, name='line-chart-labeled'),
 ]

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -4,6 +4,13 @@ from django.shortcuts import render, redirect
 
 from .forms import UserForm
 
+# Central UI colors
+# Obtained from pastel colors (top row) of:
+# https://flatuicolors.com/palette/ru
+FLAT_UI_COLORS = [
+    '#f3a683', '#f7d794', '#778beb', '#e77f67', '#cf6a87',
+    '#786fa6', '#f8a5c2', '#63cdda', '#ea8685', '#596275'
+]
 def home(request):
     text = "Welcome! Please log in to continue."
     if request.user.pk:
@@ -89,4 +96,5 @@ def pie_chart(request):
         'title': 'Population (test)',
         'labels': labels,
         'data': data,
+        'backgroundColors': FLAT_UI_COLORS,
     })

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -46,6 +46,36 @@ def pie_chart(request):
             'country_id': 21,
             'population': 25514000,
         }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
+            'id': 4,
+            'name': 'Seoul',
+            'country_id': 21,
+            'population': 25514000,
+        }, {
             'id': 5,
             'name': 'Guangzhou',
             'country_id': 13,
@@ -56,6 +86,7 @@ def pie_chart(request):
     data = [x['population'] for x in test_data]
 
     return render(request, 'pie_chart.html', {
+        'title': 'Population (test)',
         'labels': labels,
         'data': data,
     })

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -11,6 +11,66 @@ FLAT_UI_COLORS = [
     '#f3a683', '#f7d794', '#778beb', '#e77f67', '#cf6a87',
     '#786fa6', '#f8a5c2', '#63cdda', '#ea8685', '#596275'
 ]
+
+# Temporary test data
+test_data = [
+    {
+        'id': 1,
+        'name': 'Tokyo',
+        'country_id': 28,
+        'population': 36923000,
+    }, {
+        'id': 2,
+        'name': 'Shanghai',
+        'country_id': 13,
+        'population': 34000000,
+    }, {
+        'id': 3,
+        'name': 'Jakarta',
+        'country_id': 19,
+        'population': 30000000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 4,
+        'name': 'Seoul',
+        'country_id': 21,
+        'population': 25514000,
+    }, {
+        'id': 5,
+        'name': 'Guangzhou',
+        'country_id': 13,
+        'population': 25000000,
+    }]
+
 def home(request):
     text = "Welcome! Please log in to continue."
     if request.user.pk:
@@ -31,64 +91,7 @@ def signup(request):
     return render(request, 'signup.html', { 'form': form })
 
 def pie_chart(request):
-    test_data = [
-        {
-            'id': 1,
-            'name': 'Tokyo',
-            'country_id': 28,
-            'population': 36923000,
-        }, {
-            'id': 2,
-            'name': 'Shanghai',
-            'country_id': 13,
-            'population': 34000000,
-        }, {
-            'id': 3,
-            'name': 'Jakarta',
-            'country_id': 19,
-            'population': 30000000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 4,
-            'name': 'Seoul',
-            'country_id': 21,
-            'population': 25514000,
-        }, {
-            'id': 5,
-            'name': 'Guangzhou',
-            'country_id': 13,
-            'population': 25000000,
-        }]
-
+    global test_data
     labels = [x['name'] for x in test_data]
     data = [x['population'] for x in test_data]
 
@@ -97,4 +100,19 @@ def pie_chart(request):
         'labels': labels,
         'data': data,
         'backgroundColors': FLAT_UI_COLORS,
+    })
+
+def line_chart_labeled(request):
+    global test_data
+    labels = [x['name'] for x in test_data]
+    data = [x['population'] for x in test_data]
+
+    return render(request, 'line_chart_labeled.html', {
+        'title': 'Population (test)',
+        'labels': labels,
+        'data': data,
+        'backgroundColor': FLAT_UI_COLORS[8],
+        'borderColor': FLAT_UI_COLORS[9],
+        'xLabel': 'City',
+        'yLabel': 'Population',
     })


### PR DESCRIPTION
This commit initalizes a kind of API I think will be useful for us, which can be seen in the header comments of each template HTML file.

We can then use this to create a dashboard by piecing these together. For example:
```
{% include 'pie_chart.html' with
   data=pie_data
   labels=pie_labels
   backgroundColors=pie_background_colors %}
```

**EDIT**: Unfortunately, you cannot make the include templates that nice. They all have to be shoved onto one line. It may be tedious but it should still get the job done :sweat_smile:. I do have another branch currently ready that utilizes one of these, but I'll wait for this branch to get confirmed.

---

Note we currently have just a pie chart and line graph, which I think is a good start. However, [Chart.js](https://www.chartjs.org/) has a bunch more we could also implement should we want, and I don't want to wind up implementing something we don't need.

For instance, to compare some features, we want need a bar graph *or* this fancy [radar graph](https://www.chartjs.org/docs/latest/charts/radar.html).

Thankfully, implementing these graphs from this point on will be a lot of copy and paste.