### PR TITLE
Add "Upload Data" page

### DIFF
--- a/cc_midterm/cc_midterm/forms.py
+++ b/cc_midterm/cc_midterm/forms.py
@@ -12,6 +12,6 @@ class UserForm(UserCreationForm):
         fields = ('username', 'email', 'password1', 'password2')
 
 class UploadForm(forms.Form):
-    households = forms.FileField()
-    products = forms.FileField()
-    transactions = forms.FileField()
+    households = forms.FileField(required=False)
+    products = forms.FileField(required=False)
+    transactions = forms.FileField(required=False)

--- a/cc_midterm/cc_midterm/forms.py
+++ b/cc_midterm/cc_midterm/forms.py
@@ -2,9 +2,16 @@ from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 
+from .models import *
+
 class UserForm(UserCreationForm):
     email = forms.EmailField()
 
     class Meta:
         model = User
         fields = ('username', 'email', 'password1', 'password2')
+
+class UploadForm(forms.Form):
+    households = forms.FileField()
+    products = forms.FileField()
+    transactions = forms.FileField()

--- a/cc_midterm/cc_midterm/forms.py
+++ b/cc_midterm/cc_midterm/forms.py
@@ -2,8 +2,6 @@ from django import forms
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 
-from .models import *
-
 class UserForm(UserCreationForm):
     email = forms.EmailField()
 

--- a/cc_midterm/cc_midterm/models.py
+++ b/cc_midterm/cc_midterm/models.py
@@ -1,7 +1,10 @@
 from django.db import models
+from bulk_update_or_create import BulkUpdateOrCreateQuerySet
 
 
 class Households(models.Model):
+    objects = BulkUpdateOrCreateQuerySet.as_manager()
+
     hshd_num = models.SmallIntegerField(db_column='HSHD_NUM', primary_key=True)  # Field name made lowercase.
     l = models.CharField(db_column='L', max_length=10, blank=True, null=True)  # Field name made lowercase.
     age_range = models.CharField(db_column='AGE_RANGE', max_length=250, blank=True, null=True)  # Field name made lowercase.
@@ -17,6 +20,8 @@ class Households(models.Model):
 
 
 class Products(models.Model):
+    objects = BulkUpdateOrCreateQuerySet.as_manager()
+
     product_num = models.IntegerField(db_column='PRODUCT_NUM', primary_key=True)  # Field name made lowercase.
     department = models.CharField(db_column='DEPARTMENT', max_length=250, blank=True, null=True)  # Field name made lowercase.
     commodity = models.CharField(db_column='COMMODITY', max_length=250, blank=True, null=True)  # Field name made lowercase.
@@ -28,6 +33,8 @@ class Products(models.Model):
 
 
 class Transactions(models.Model):
+    objects = BulkUpdateOrCreateQuerySet.as_manager()
+
     basket_num = models.CharField(db_column='BASKET_NUM', max_length=250, primary_key=True)  # Field name made lowercase.
     hshd_num = models.ForeignKey(Households, on_delete=models.CASCADE, db_column='HSHD_NUM', blank=True, null=True)  # Field name made lowercase.
     purchase = models.DateField(db_column='PURCHASE', blank=True, null=True)  # Field name made lowercase.

--- a/cc_midterm/cc_midterm/settings.py
+++ b/cc_midterm/cc_midterm/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_tables2',
+    'bulk_update_or_create',
     'cc_midterm',
 ]
 

--- a/cc_midterm/cc_midterm/templates/base.html
+++ b/cc_midterm/cc_midterm/templates/base.html
@@ -27,7 +27,6 @@
         <span><a href="/data-table">Data Table</a></span>
         &nbsp
         <span><a href="/upload">Upload Data</a></span>
-        <hr/>
     </nav>
     <body>
         <div style="padding: 24px">

--- a/cc_midterm/cc_midterm/templates/base.html
+++ b/cc_midterm/cc_midterm/templates/base.html
@@ -25,6 +25,9 @@
         <span style="border-left:1px solid #FFF;height:100%; margin: 6px"></span>
         &nbsp
         <span><a href="/data-table">Data Table</a></span>
+        &nbsp
+        <span><a href="/upload">Upload Data</a></span>
+        <hr/>
     </nav>
     <body>
         <div style="padding: 24px">

--- a/cc_midterm/cc_midterm/templates/upload.html
+++ b/cc_midterm/cc_midterm/templates/upload.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>Upload Data</h1>
-    <form method="POST">
+    <h2>Upload Data</h2>
+    <form method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form.as_p }}
         <button type="submit">Upload</button>

--- a/cc_midterm/cc_midterm/templates/upload.html
+++ b/cc_midterm/cc_midterm/templates/upload.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Upload Data</h1>
+    <form method="POST">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit">Upload</button>
+    </form>
+{% endblock %}

--- a/cc_midterm/cc_midterm/templates/upload.html
+++ b/cc_midterm/cc_midterm/templates/upload.html
@@ -7,4 +7,7 @@
         {{ form.as_p }}
         <button type="submit">Upload</button>
     </form>
+    <p>
+        <i>Note: uploads may take a while...</i>
+    </p>
 {% endblock %}

--- a/cc_midterm/cc_midterm/uploads.py
+++ b/cc_midterm/cc_midterm/uploads.py
@@ -1,0 +1,76 @@
+from .models import *
+
+
+def upload_households(households_file):
+    households_rows = households_file.split('\n')
+
+    households = []
+    for i in range(1, len(households_rows)):
+        if households_rows[i] == '': # Empty row: just move on to the next one
+            continue
+
+        row_values = households_rows[i].split(',')
+
+        h = Households(
+                hshd_num=int(row_values[0].strip()),
+                l=row_values[1],
+                age_range=row_values[2],
+                marital=row_values[3],
+                income_range=row_values[4],
+                homeowner=row_values[5],
+                hshd_composition=row_values[6],
+                hh_size=row_values[7],
+                children=row_values[8]
+            )
+
+        households.append(h)
+        
+        # Households.objects.bulk_update_or_create(households, ['l', 'age_range', 'marital', 'income_range', 'homeowner', 'hshd_composition', 'hh_size', 'children'], match_field='hshd_num')
+
+def upload_products(products_file):
+    products_rows = products_file.split('\n')
+
+    products = []
+    for i in range(1, len(products_rows)):
+        if products_rows[i] == '': # Empty row: just move on to the next one
+            continue
+
+        row_values = products_rows[i].split(',')
+
+        p = Products(
+                product_num=int(row_values[0].strip()),
+                department=row_values[1],
+                commodity=row_values[2],
+                brand_ty=row_values[3],
+                natural_organic_flag=row_values[4]
+            )
+
+        products.append(p)
+
+        # Products.objects.bulk_update_or_create(products, ['department', 'commodity', 'brand_ty', 'natural_organic_flag'], match_fields='product_num')
+
+def upload_transactions(transactions_file):
+    transactions_rows = transactions_file.split('\n')
+
+    transactions = []
+    for i in range(1, len(transactions_rows)):
+        if transactions_rows[i] == '': # Empty row: just move on to the next one
+            continue
+
+        row_values = transactions_rows[i].split(',')
+
+        p = transactions(
+                basket_num=int(row_values[0].strip()),
+                hshd_num=row_values[1],
+                purchase=row_values[2],
+                product_num=row_values[3],
+                spend=row_values[4],
+                units=row_values[5],
+                store_r=row_values[6],
+                week_num=row_values[7],
+                year=row_values[8]
+            )
+
+        transactions.append(p)
+
+        # transactions.objects.bulk_update_or_create(transactions, ['hshd_num', 'purchase', 'product_num', 'spend', 'units', 'store_r', 'week_num', 'year'], match_fields='basket_num')

--- a/cc_midterm/cc_midterm/uploads.py
+++ b/cc_midterm/cc_midterm/uploads.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from .models import *
 
 
@@ -25,7 +27,7 @@ def upload_households(households_file):
 
         households.append(h)
         
-        # Households.objects.bulk_update_or_create(households, ['l', 'age_range', 'marital', 'income_range', 'homeowner', 'hshd_composition', 'hh_size', 'children'], match_field='hshd_num')
+        Households.objects.bulk_update_or_create(households, ['l', 'age_range', 'marital', 'income_range', 'homeowner', 'hshd_composition', 'hh_size', 'children'], match_field='hshd_num') # Update outdated household info or insert if it doesn't already exist
 
 def upload_products(products_file):
     products_rows = products_file.split('\n')
@@ -47,7 +49,7 @@ def upload_products(products_file):
 
         products.append(p)
 
-        # Products.objects.bulk_update_or_create(products, ['department', 'commodity', 'brand_ty', 'natural_organic_flag'], match_fields='product_num')
+        Products.objects.bulk_update_or_create(products, ['department', 'commodity', 'brand_ty', 'natural_organic_flag'], match_field='product_num') # Update outdated product info or insert if it doesn't already exist
 
 def upload_transactions(transactions_file):
     transactions_rows = transactions_file.split('\n')
@@ -59,11 +61,11 @@ def upload_transactions(transactions_file):
 
         row_values = transactions_rows[i].split(',')
 
-        p = transactions(
+        t = Transactions(
                 basket_num=int(row_values[0].strip()),
-                hshd_num=row_values[1],
-                purchase=row_values[2],
-                product_num=row_values[3],
+                hshd_num_id=row_values[1],
+                purchase=datetime.strptime(row_values[2], '%d-%b-%y'),
+                product_num_id=row_values[3],
                 spend=row_values[4],
                 units=row_values[5],
                 store_r=row_values[6],
@@ -71,6 +73,6 @@ def upload_transactions(transactions_file):
                 year=row_values[8]
             )
 
-        transactions.append(p)
+        transactions.append(t)
 
-        # transactions.objects.bulk_update_or_create(transactions, ['hshd_num', 'purchase', 'product_num', 'spend', 'units', 'store_r', 'week_num', 'year'], match_fields='basket_num')
+        Transactions.objects.bulk_create(transactions) # Using standard bulk_create because old transaction records shouldn't be updated with new ones. Just insert the new ones.

--- a/cc_midterm/cc_midterm/urls.py
+++ b/cc_midterm/cc_midterm/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('engagement-over-time/', views.engagement_over_time, name='engagement-over-time'),
     path('engagement-per-factor/', views.engagement_per_factor, name='engagement-per-factor'),
     path('data-table/', views.data_table, name='data-table'),
+    path('upload/', views.upload, name='upload'),
     # Temp for testing
     path('pie-chart/', views.pie_chart, name='pie-chart'),
     path('line-chart-labeled/', views.line_chart_labeled, name='line-chart-labeled'),

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -8,6 +8,7 @@ from .forms import *
 from .data import *
 from .models import *
 from .tables import *
+from .uploads import *
 
 # Central UI colors
 # Obtained from pastel colors (top row) of:
@@ -94,78 +95,13 @@ def upload(request):
         form = UploadForm(request.POST, request.FILES)
         
         households_file = request.FILES['households'].open('r').read().decode('utf-8')
-        households_rows = households_file.split('\n')
-
-        households = []
-        for i in range(1, len(households_rows)):
-            if households_rows[i] == '': # Empty row: just move on to the next one
-                continue
-
-            row_values = households_rows[i].split(',')
-
-            h = Households(
-                    hshd_num=int(row_values[0].strip()),
-                    l=row_values[1],
-                    age_range=row_values[2],
-                    marital=row_values[3],
-                    income_range=row_values[4],
-                    homeowner=row_values[5],
-                    hshd_composition=row_values[6],
-                    hh_size=row_values[7],
-                    children=row_values[8]
-                )
-
-            households.append(h)
+        upload_households(households_file)
         
-        # Households.objects.bulk_update_or_create(households, ['l', 'age_range', 'marital', 'income_range', 'homeowner', 'hshd_composition', 'hh_size', 'children'], match_field='hshd_num')
-    
         products_file = request.FILES['products'].open('r').read().decode('utf-8')
-        products_rows = products_file.split('\n')
-
-        products = []
-        for i in range(1, len(products_rows)):
-            if products_rows[i] == '': # Empty row: just move on to the next one
-                continue
-
-            row_values = products_rows[i].split(',')
-
-            p = Products(
-                    product_num=int(row_values[0].strip()),
-                    department=row_values[1],
-                    commodity=row_values[2],
-                    brand_ty=row_values[3],
-                    natural_organic_flag=row_values[4]
-                )
-
-            products.append(p)
-
-        # Products.objects.bulk_update_or_create(products, ['department', 'commodity', 'brand_ty', 'natural_organic_flag'], match_fields='product_num')
+        upload_products(products_file)
 
         transactions_file = request.FILES['transactions'].open('r').read().decode('utf-8')
-        transactions_rows = transactions_file.split('\n')
-
-        transactions = []
-        for i in range(1, len(transactions_rows)):
-            if transactions_rows[i] == '': # Empty row: just move on to the next one
-                continue
-
-            row_values = transactions_rows[i].split(',')
-
-            p = transactions(
-                    basket_num=int(row_values[0].strip()),
-                    hshd_num=row_values[1],
-                    purchase=row_values[2],
-                    product_num=row_values[3],
-                    spend=row_values[4],
-                    units=row_values[5],
-                    store_r=row_values[6],
-                    week_num=row_values[7],
-                    year=row_values[8]
-                )
-
-            transactions.append(p)
-
-        # transactions.objects.bulk_update_or_create(transactions, ['hshd_num', 'purchase', 'product_num', 'spend', 'units', 'store_r', 'week_num', 'year'], match_fields='basket_num')
+        upload_transactions(transactions_file)
 
     else:
         form = UploadForm()

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -92,8 +92,81 @@ def engagement_over_time(request):
 def upload(request):
     if request.method == 'POST':
         form = UploadForm(request.POST, request.FILES)
-        return HttpResponse()
+        
+        households_file = request.FILES['households'].open('r').read().decode('utf-8')
+        households_rows = households_file.split('\n')
+
+        households = []
+        for i in range(1, len(households_rows)):
+            if households_rows[i] == '': # Empty row: just move on to the next one
+                continue
+
+            row_values = households_rows[i].split(',')
+
+            h = Households(
+                    hshd_num=int(row_values[0].strip()),
+                    l=row_values[1],
+                    age_range=row_values[2],
+                    marital=row_values[3],
+                    income_range=row_values[4],
+                    homeowner=row_values[5],
+                    hshd_composition=row_values[6],
+                    hh_size=row_values[7],
+                    children=row_values[8]
+                )
+
+            households.append(h)
+        
+        # Households.objects.bulk_update_or_create(households, ['l', 'age_range', 'marital', 'income_range', 'homeowner', 'hshd_composition', 'hh_size', 'children'], match_field='hshd_num')
     
+        products_file = request.FILES['products'].open('r').read().decode('utf-8')
+        products_rows = products_file.split('\n')
+
+        products = []
+        for i in range(1, len(products_rows)):
+            if products_rows[i] == '': # Empty row: just move on to the next one
+                continue
+
+            row_values = products_rows[i].split(',')
+
+            p = Products(
+                    product_num=int(row_values[0].strip()),
+                    department=row_values[1],
+                    commodity=row_values[2],
+                    brand_ty=row_values[3],
+                    natural_organic_flag=row_values[4]
+                )
+
+            products.append(p)
+
+        # Products.objects.bulk_update_or_create(products, ['department', 'commodity', 'brand_ty', 'natural_organic_flag'], match_fields='product_num')
+
+        transactions_file = request.FILES['transactions'].open('r').read().decode('utf-8')
+        transactions_rows = transactions_file.split('\n')
+
+        transactions = []
+        for i in range(1, len(transactions_rows)):
+            if transactions_rows[i] == '': # Empty row: just move on to the next one
+                continue
+
+            row_values = transactions_rows[i].split(',')
+
+            p = transactions(
+                    basket_num=int(row_values[0].strip()),
+                    hshd_num=row_values[1],
+                    purchase=row_values[2],
+                    product_num=row_values[3],
+                    spend=row_values[4],
+                    units=row_values[5],
+                    store_r=row_values[6],
+                    week_num=row_values[7],
+                    year=row_values[8]
+                )
+
+            transactions.append(p)
+
+        # transactions.objects.bulk_update_or_create(transactions, ['hshd_num', 'purchase', 'product_num', 'spend', 'units', 'store_r', 'week_num', 'year'], match_fields='basket_num')
+
     else:
         form = UploadForm()
     

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render, redirect
 from django_tables2 import RequestConfig
 
 from .models import Households, Products, Transactions
-from .forms import UserForm
+from .forms import *
 from .data import *
 from .models import *
 from .tables import *
@@ -88,6 +88,16 @@ def engagement_over_time(request):
         'all_data_props': all_data_props,
         'per_house_props': per_house_props,
     })
+    
+def upload(request):
+    if request.method == 'POST':
+        form = UploadForm(request.POST, request.FILES)
+        return HttpResponse()
+    
+    else:
+        form = UploadForm()
+    
+    return render(request, 'upload.html', { 'form': form })
 
 def engagement_per_factor(request):
     # Get general data

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -94,14 +94,19 @@ def upload(request):
     if request.method == 'POST':
         form = UploadForm(request.POST, request.FILES)
         
-        households_file = request.FILES['households'].open('r').read().decode('utf-8')
-        upload_households(households_file)
+        if 'households' in request.FILES.keys():
+            households_file = request.FILES['households'].open('r').read().decode('utf-8')
+            upload_households(households_file)
         
-        products_file = request.FILES['products'].open('r').read().decode('utf-8')
-        upload_products(products_file)
+        if 'products' in request.FILES.keys():
+            products_file = request.FILES['products'].open('r').read().decode('utf-8')
+            upload_products(products_file)
 
-        transactions_file = request.FILES['transactions'].open('r').read().decode('utf-8')
-        upload_transactions(transactions_file)
+        if 'transactions' in request.FILES.keys():
+            transactions_file = request.FILES['transactions'].open('r').read().decode('utf-8')
+            upload_transactions(transactions_file)
+
+        return redirect('data-table')
 
     else:
         form = UploadForm()

--- a/cc_midterm/cc_midterm/views.py
+++ b/cc_midterm/cc_midterm/views.py
@@ -94,15 +94,17 @@ def upload(request):
     if request.method == 'POST':
         form = UploadForm(request.POST, request.FILES)
         
-        if 'households' in request.FILES.keys():
+        # Before processing, make sure the file exists and is a .csv file
+
+        if 'households' in request.FILES.keys() and request.FILES['households'].name.endswith('.csv'):
             households_file = request.FILES['households'].open('r').read().decode('utf-8')
             upload_households(households_file)
         
-        if 'products' in request.FILES.keys():
+        if 'products' in request.FILES.keys() and request.FILES['products'].name.endswith('.csv'):
             products_file = request.FILES['products'].open('r').read().decode('utf-8')
             upload_products(products_file)
 
-        if 'transactions' in request.FILES.keys():
+        if 'transactions' in request.FILES.keys() and request.FILES['transactions'].name.endswith('.csv'):
             transactions_file = request.FILES['transactions'].open('r').read().decode('utf-8')
             upload_transactions(transactions_file)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Django==3.0.10
 pyodbc>=4.0
 django-mssql-backend==2.8.1
 django-tables2==2.3.4
+django-bulk-update-or-create==0.2.0


### PR DESCRIPTION
This is a page where a user can upload .csv files for households, products, and transactions to be added to the database.

The server expects the uploaded files to follow the same format as the ones found in the sample dataset (i.e. CSV file, column headers, and same column order). *The biggest concern is the static column order; I will reach out to the professor and ask him if this is acceptable or if we should allow for any order of columns.* If we need to allow for any order of columns, we need to rework how attributes are assigned when reading from the file (likely just reading the column headers first and then following the same index for the values).

The products and households uploads will update a row if the corresponding `product_num` or `hshd_num` (respectively) already exists, and only insert if it doesn't exist. This is to allow for things like price changes and family size changes. Transactions, on the other hand, will only insert and never update. Once a transaction in the store has been made, it doesn't really make sense to be modifying the data for it years later.

The best way I have found to test this is to take the sample CSV files that were given, make copies of them, and shorten those copies to only include a handful of rows. You can then modify the values of those rows however you see fit. Just remember to delete any new inserts after you are done testing, as we don't want any junk test data to stay in there longer than it needs to.

If, by chance, any uploaded data causes the server to not work as expected or produces errors, I have made backup tables for each of households, products, and transactions. This will allow us to recover much quicker than trying to import the sample CSV files into the database again.